### PR TITLE
implement argument passing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,8 @@ pub enum CliSubcommand {
     Run {
         /// The alias or name for the script.
         alias: String,
+        #[structopt(short = "a", long = "args")]
+        args: Option<Vec<String>>
     },
     /// alias: ls - List scripts
     ///
@@ -98,15 +100,14 @@ pub struct CliOpts {
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(setting = AppSettings::SubcommandsNegateReqs, author)]
+#[structopt(setting = AppSettings::ArgsNegateSubcommands, author)]
 /// A simple script management CLI
 pub struct Cli {
     #[structopt(flatten)]
     pub opts: CliOpts,
 
-    /// The alias or name for the script.
-    #[structopt(required_unless = "cmd")]
-    pub alias: Option<String>,
+    /// The alias or name for the script and arguments fot that.
+    pub alias_and_args: Vec<String>,
 
     /// Pier subcommands
     #[structopt(subcommand)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl Pier {
     }
 
     /// Runs a script and print stdout and stderr of the command.
-    pub fn run_script(&self, alias: &str, _arg: &str) -> Result<()> {
+    pub fn run_script(&self, alias: &str, args: &[String]) -> Result<()> {
         let script = self.fetch_script(alias)?;
         let interpreter = match self.config.default.interpreter {
             Some(ref interpreter) => interpreter.clone(),
@@ -215,8 +215,8 @@ impl Pier {
         };
 
         let cmd = match script.has_shebang() {
-            true => script.run_with_shebang()?,
-            false => script.run_with_cli_interpreter(&interpreter)?,
+            true => script.run_with_shebang(args)?,
+            false => script.run_with_cli_interpreter(&interpreter, args)?,
         };
 
         let stdout = String::from_utf8_lossy(&cmd.stdout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,15 +66,14 @@ fn handle_subcommands(cli: Cli) -> Result<()> {
                     pier.list_scripts(tags, cmd_full, cmd_width)?
                 }
             }
-            CliSubcommand::Run { alias } => {
-                let arg = "";
-                pier.run_script(&alias, arg)?;
+            CliSubcommand::Run { alias, args } => {
+                let args = if let Some(a) = args {a} else {vec![]};
+                pier.run_script(&alias, &args)?;
             }
         };
     } else {
-        let arg = "";
-        let alias = &cli.alias.expect("Alias is required unless subcommand.");
-        pier.run_script(alias, arg)?;
+        let alias = cli.alias_and_args;
+        pier.run_script(&alias.get(0).expect("Alias is required unless subcommand."), &alias[1..])?;
     }
 
     Ok(())

--- a/src/script.rs
+++ b/src/script.rs
@@ -38,12 +38,13 @@ impl Script {
         }
     }
     /// Runs the script inline using something like sh -c "<script>" or python -c "<script."...
-    pub fn run_with_cli_interpreter(&self, interpreter: &Vec<String>) -> Result<Output> {
+    pub fn run_with_cli_interpreter(&self, interpreter: &Vec<String>, args: &[String]) -> Result<Output> {
         // First item in interpreter is the binary
         let cmd = Command::new(&interpreter[0])
             // The following items after the binary is any commandline args that are necessary.
             .args(&interpreter[1..])
             .arg(&self.command)
+            .args(args)
             .stderr(Stdio::piped())
             .spawn()
             .context(CommandExec)?
@@ -54,7 +55,7 @@ impl Script {
     }
 
     /// First creates a temporary file and then executes the file before removing it.
-    pub fn run_with_shebang(&self) -> Result<Output> {
+    pub fn run_with_shebang(&self, args: &[String]) -> Result<Output> {
         // Creates a temp directory to place our tempfile inside.
         let tmpdir = tempfile::Builder::new()
             .prefix("pier")
@@ -86,6 +87,7 @@ impl Script {
         }
 
         let cmd = Command::new(exec_file_path)
+            .args(args)
             .stderr(Stdio::piped())
             .spawn()
             .context(CommandExec)?


### PR DESCRIPTION
If pier supports passing arguments to the scripts, it would be flexible. So I have tried to implement.

I wanted to split alias and arguments which are combined into a `Vec<String>` in `Cli` structure, but when I tried, the binary always crashed. I would happy if someone implements that :).