### PR TITLE
Fix two issues with pier list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,16 @@ impl Pier {
 
                     continue;
                 }
+                (None, None, Some(description)) => {
+                    table.add_row(row![
+                        &alias,
+                        "",
+                        description,
+                        script.display_command(cmd_full, width)
+                    ]);
+
+                    continue;
+                }
                 (None, None, None) => {
                     table.add_row(row![&alias, "", "", script.display_command(cmd_full, width)]);
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -31,7 +31,7 @@ impl Script {
                 match &self.command.lines().nth(0) {
                     Some(line) => {
                         match line.chars().count() {
-                            c if c < width => line,
+                            c if c <= width => line,
                             c if c > width => &line[0..width],
                             _ => "",
                         }


### PR DESCRIPTION
### Issue one

Commands that are exactly `width` characters long don't display correctly in `pier list`'s output.

For example, assuming a console width of 80 characters, and using the following `config.toml`:
```toml
[scripts.example-command]
alias = 'example-command'
command = 'this string is precisely eighty characters long - which causes a issues with list.'

[default]

```

Pier would erroneously output the following:
```
$ pier list
+-----------------+--------+-------------+---------+
| Alias           | Tag(s) | Description | Command |
+=================+========+=============+=========+
| example-command |        |             |         |
+-----------------+--------+-------------+---------+

```

With the fix applied:

```
$ pier list
+-----------------+--------+-------------+----------------------------------------------------------------------------------+
| Alias           | Tag(s) | Description | Command                                                                          |
+=================+========+=============+==================================================================================+
| example-command |        |             | this string is precisely eighty characters long - which causes issues with list. |
+-----------------+--------+-------------+----------------------------------------------------------------------------------+
```

### Issue two

Entries that have a description, but *don't* have tags, aren't printed at all by pier list.

Using the following `config.toml`:
```toml
[scripts.example-command]
alias = 'example-command'
command = 'echo hi'
description = 'some kind of description'

[default]

```

Pier would output:
```
$ pier list
++
||
++
++
```

With the fix applied:
```
$ pier list
+-----------------+--------+--------------------------+---------+
| Alias           | Tag(s) | Description              | Command |
+=================+========+==========================+=========+
| example-command |        | some kind of description | echo hi |
+-----------------+--------+--------------------------+---------+
```

I have verified that all tests complete successfully.