### PR TITLE
Add rename/move subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,10 @@ pub enum CliSubcommand {
         /// Set which tags the script belongs to.
         #[structopt(short = "t", long = "tag")]
         tags: Option<Vec<String>>,
+
+        /// Allows to overwrite the existing script
+        #[structopt(short = "f", long = "force")]
+        force: bool,
     },
     /// alias: rm - Remove a script matching alias.
     #[structopt(alias = "rm")]
@@ -76,11 +80,24 @@ pub enum CliSubcommand {
         #[structopt(short = "t", long = "tag")]
         tags: Option<Vec<String>>,
     },
-    // Copy existing alias to the new one
+    /// alias: cp - Copy existing alias to the new one
     #[structopt(alias = "cp")]
     Copy {
+        /// The alias of the script that will be copied.
         from_alias: String,
+        /// The new alias of the copy of the script.
         to_alias: String,
+    },
+    /// alias: mv, rename - Move/rename existing alias to the new one
+    #[structopt(aliases = &["mv", "rename"])]
+    Move {
+        /// The alias of the script that will be moved.
+        from_alias: String,
+        /// The new alias of the script.
+        to_alias: String,
+        /// Allows to overwrite the existing script
+        #[structopt(short = "f", long = "force")]
+        force: bool,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn handle_subcommands(cli: Cli) -> Result<Option<process::ExitStatus>> {
                 alias,
                 description,
                 tags,
+                force,
             } => {
                 let mut pier = Pier::from(cli.opts.path, cli.opts.verbose)?;
                 pier.add_script(Script {
@@ -47,7 +48,7 @@ fn handle_subcommands(cli: Cli) -> Result<Option<process::ExitStatus>> {
                     },
                     tags,
                     reference: None,
-                })?;
+                }, force)?;
                 pier.write()?;
             }
 
@@ -94,6 +95,15 @@ fn handle_subcommands(cli: Cli) -> Result<Option<process::ExitStatus>> {
             } => {
                 let mut pier = Pier::from(cli.opts.path, cli.opts.verbose)?;
                 pier.copy_script(&from_alias, &to_alias)?;
+                pier.write()?;
+            }
+            CliSubcommand::Move {
+                from_alias,
+                to_alias,
+                force,
+            } => {
+                let mut pier = Pier::from(cli.opts.path, cli.opts.verbose)?;
+                pier.move_script(&from_alias, &to_alias, force)?;
                 pier.write()?;
             }
         };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -191,6 +191,21 @@ pier_test!(cli => test_add_script, cfg => CONFIG_1,
     );
 });
 
+// Tests adding a script with forcing
+pier_test!(cli => test_add_script_force_script, cfg => CONFIG_1,
+| cfg: ChildPath, mut cmd: Command | {
+    cmd.args(&["add", r#"echo test_3"#, "-a", "test_cmd_1", "-d", "Test Description.", "-f"]);
+    cmd.assert().success();
+
+    cfg.assert(contains(trim!(r#"
+        [scripts.test_cmd_1]
+        alias = 'test_cmd_1'
+        command = 'echo test_3'
+        description = 'Test Description.'
+    "#)).trim()
+    );
+});
+
 // Tests copying a script
 pier_test!(cli => test_copy_script, cfg => CONFIG_1,
 | cfg: ChildPath, mut cmd: Command | {
@@ -202,6 +217,46 @@ pier_test!(cli => test_copy_script, cfg => CONFIG_1,
             alias = 'test_cmd_1'
             command = 'echo test_1'
         "#)).trim()
+    );
+});
+
+// Tests moving a script
+pier_test!(cli => test_move_script, cfg => CONFIG_1,
+| cfg: ChildPath, mut cmd: Command | {
+    cmd.args(&["move", "test_cmd_1", "test_cmd_4"]);
+    cmd.assert().success();
+
+    cfg.assert(contains(trim!(r#"
+            [scripts.test_cmd_4]
+            alias = 'test_cmd_1'
+            command = 'echo test_1'
+        "#)).trim()
+    );
+    cfg.assert(contains(trim!(r#"
+            [scripts.test_cmd_1]
+            alias = 'test_cmd_1'
+            command = 'echo test_1'
+        "#)).trim().not()
+    );
+});
+
+// Tests moving a script with forcing
+pier_test!(cli => test_move_with_force_script, cfg => CONFIG_1,
+| cfg: ChildPath, mut cmd: Command | {
+    cmd.args(&["move", "test_cmd_1", "test_cmd_2", "-f"]);
+    cmd.assert().success();
+
+    cfg.assert(contains(trim!(r#"
+            [scripts.test_cmd_2]
+            alias = 'test_cmd_1'
+            command = 'echo test_1'
+        "#)).trim()
+    );
+    cfg.assert(contains(trim!(r#"
+            [scripts.test_cmd_1]
+            alias = 'test_cmd_1'
+            command = 'echo test_1'
+        "#)).trim().not()
     );
 });
 

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -34,7 +34,19 @@ command = 'echo test_1'
     reference: None,
     tags: None
     };
-    err_eq!(lib.add_script(script), AliasAlreadyExists);
+    err_eq!(lib.add_script(script, false), AliasAlreadyExists);
+});
+
+pier_test!(lib => test_error_alias_already_exists_on_move, cfg => r#"
+[scripts.test_cmd_1]
+alias = 'test_cmd_1'
+command = 'echo test_1'
+
+[scripts.test_cmd_2]
+alias = 'test_cmd_2'
+command = 'echo test_2'
+"#, | _cfg: ChildPath, mut lib: Pier | {
+    err_eq!(lib.move_script("test_cmd_1", "test_cmd_2",  false), AliasAlreadyExists);
 });
 
 // Tests that it returns the error ConfigRead if the file cannot be read.


### PR DESCRIPTION
Hi everyone,
This is my first PR here. I find this tool useful for myself and I want to practice in Rust.

Added rename/move sub-command with ability to force an overwriting of existing scripts.
Also, added `force` flag to Add sub-command.

Fixes #46
